### PR TITLE
set progress to 1 when video ends

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,6 +167,8 @@ export default class VideoPlayer extends Component {
       this.setState({ isStarted: false });
     }
 
+    this.setState({ progress: 1 });
+
     this.player.seek(0);
     if (!this.props.loop) {
       this.setState({


### PR DESCRIPTION
I noticed when testing with shorter videos (less than 10 seconds) that
the progress indicator never quite reached the end.  This confused a few
users.  By setting progress to 1 when the onEnd event fires, the
progress indicator reaches all the way to the end as expected.