### PR TITLE
Exit fullscreen if endWithThumbnail is set

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,6 +170,7 @@ export default class VideoPlayer extends Component {
 
     if (this.props.endWithThumbnail) {
       this.setState({ isStarted: false });
+      this.player.dismissFullscreenPlayer();
     }
 
     this.setState({ progress: 1 });


### PR DESCRIPTION
If `endWithThumbnail` is set and the video is in fullscreen when the video ends, the player remains in an all-black screen with no means of exiting.

Calling `dismissFullscreenPlayer()` will exit fullscreen if it's active and have no effect otherwise.