### PR TITLE
Fix video repeating when loop turned off

### DIFF
--- a/index.js
+++ b/index.js
@@ -178,11 +178,13 @@ export default class VideoPlayer extends Component {
 
     this.setState({ progress: 1 });
 
-    this.player.seek(0);
     if (!this.props.loop) {
-      this.setState({
-        isPlaying: false,
-      });
+      this.setState(
+        { isPlaying: false },
+        () => this.player.seek(0)
+      );
+    } else {
+      this.player.seek(0);
     }
   }
 


### PR DESCRIPTION
Makes sure the video is paused before seeking. This fixes the issue (in #68) where videos, that are not meant to loop, are continuing to play after the onEnd event is dispatched.