### PR TITLE
Add prop to enable pause video programmatically

### DIFF
--- a/index.js
+++ b/index.js
@@ -472,7 +472,9 @@ export default class VideoPlayer extends Component {
           ]}
           ref={p => { this.player = p; }}
           muted={this.props.muted || this.state.isMuted}
-          paused={!this.state.isPlaying}
+          paused={this.props.paused
+            ? this.props.paused || !this.state.isPlaying
+            : !this.state.isPlaying}
           onProgress={this.onProgress}
           onEnd={this.onEnd}
           onLoad={this.onLoad}
@@ -575,6 +577,7 @@ VideoPlayer.propTypes = {
   onPlayPress: PropTypes.func,
   onHideControls: PropTypes.func,
   onShowControls: PropTypes.func,
+  paused: PropTypes.bool,
 };
 
 VideoPlayer.defaultProps = {


### PR DESCRIPTION
Added ability to pause video programmatically. This is very helpful if you need ability to pause all videos or pause videos when scrolled away.

This fixes the issue #65 .
