### PR TITLE
Added ability to display different thumbnails at the beginning and end of the Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ react-native link react-native-vector-icons
 |-------------------------|---------------------------------------------------------------------------------------------|
 | video                   | The video source to pass to react-native-video.                                             |
 | thumbnail               | An Image source to use as thumbnail before the video gets loaded.                           |
+| endThumbnail            | An Image source to use as thumbnail after the video has ended.                           |
 | videoWidth              | Width of the video to calculate the player size.                                            |
 | videoHeight             | Height of the video to calculate the player size.                                           |
 | duration                | Duration can not always be figured out (e.g. when using hls), this can be used as fallback. |
@@ -32,7 +33,7 @@ react-native link react-native-vector-icons
 | loop                    | Loop the video after playback is done.                                                      |
 | resizeMode              | The video's resizeMode. defaults to contain and is passed to react-native-video.            |
 | hideControlsOnStart     | Hides the controls on start video.                                                          |
-| endWithThumbnail        | Returns to the thumbnail after the video ends.                                              |
+| endWithThumbnail        | Returns to the thumbnail after the video ends. If an `endThumbnail` image is not specified then the image specified in `thumbnail` is shown.                                              |
 | disableSeek             | Disable video seeking.                                                                      |
 | pauseOnPress            | Automatically pause/play when pressing the video player anywhere.                           |
 | fullScreenOnLongPress   | Automatically show video on fullscreen when doing a long press.                             |

--- a/index.js
+++ b/index.js
@@ -92,6 +92,7 @@ export default class VideoPlayer extends Component {
     this.state = {
       isStarted: props.autoplay,
       isPlaying: props.autoplay,
+      hasEnded: false,
       width: 200,
       progress: 0,
       isMuted: props.defaultMuted,
@@ -148,6 +149,7 @@ export default class VideoPlayer extends Component {
     this.setState(state => ({
       isPlaying: true,
       isStarted: true,
+      hasEnded: false,
       progress: state.progress === 1 ? 0 : state.progress,
     }));
 
@@ -171,8 +173,8 @@ export default class VideoPlayer extends Component {
       this.props.onEnd(event);
     }
 
-    if (this.props.endWithThumbnail) {
-      this.setState({ isStarted: false });
+    if (this.props.endWithThumbnail || this.props.endThumbnail) {
+      this.setState({ isStarted: false, hasEnded: true });
       this.player.dismissFullscreenPlayer();
     }
 
@@ -355,8 +357,8 @@ export default class VideoPlayer extends Component {
     );
   }
 
-  renderThumbnail() {
-    const { thumbnail, style, customStyles, ...props } = this.props;
+  renderThumbnail(thumbnail) {
+    const { style, customStyles, ...props } = this.props;
     return (
       <BackgroundImage
         {...props}
@@ -512,11 +514,14 @@ export default class VideoPlayer extends Component {
   }
 
   renderContent() {
-    const { thumbnail, style } = this.props;
-    const { isStarted } = this.state;
+    const { thumbnail, endThumbnail, style } = this.props;
+    const { isStarted, hasEnded } = this.state;
 
-    if (!isStarted && thumbnail) {
-      return this.renderThumbnail();
+    if (hasEnded && endThumbnail) {
+      return this.renderThumbnail(endThumbnail);
+    }
+    else if (!isStarted && thumbnail) {
+      return this.renderThumbnail(thumbnail);
     } else if (!isStarted) {
       return (
         <View style={[styles.preloadingPlaceholder, this.getSizeStyles(), style]}>
@@ -539,6 +544,7 @@ export default class VideoPlayer extends Component {
 VideoPlayer.propTypes = {
   video: Video.propTypes.source,
   thumbnail: Image.propTypes.source,
+  endThumbnail: Image.propTypes.source,
   videoWidth: PropTypes.number,
   videoHeight: PropTypes.number,
   duration: PropTypes.number,


### PR DESCRIPTION
Added a new feature to be able to display a different thumbnail after the video ends. Currently only one thumbnail image is supported and the same is shown after the vide ends if `endWithThumbnail` prop is enabled.