### PR TITLE
Add possibility to render an overlay component on video

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ allprojects {
 | onHideControls          | Callback for when the controls are being hide.                                              |
 | onShowControls          | Callback for when the controls are being shown.                                             |
 | customStyles            | The player can be customized in this object, see customStyles for the options.              |
+| renderOverlayComponent  | Render an overlay component on top of the video, but under controls / play button.          |
 
 All other props are passed to the react-native-video component.
 

--- a/index.js
+++ b/index.js
@@ -118,7 +118,8 @@ const styles = StyleSheet.create({
   },
   durationText: {
     color: 'white'
-  }
+  },
+  overlayComponentWrapper: StyleSheet.absoluteFill,
 });
 
 export default class VideoPlayer extends Component {
@@ -427,6 +428,7 @@ export default class VideoPlayer extends Component {
         ]}
         source={thumbnail}
       >
+        {this.renderOverlay()}
         {this.renderStartButton()}
       </BackgroundImage>
     );
@@ -521,6 +523,14 @@ export default class VideoPlayer extends Component {
     );
   }
 
+  renderOverlay() {
+    return this.props.renderOverlayComponent ? (
+      <View style={styles.overlayComponentWrapper}>
+        {this.props.renderOverlayComponent()}
+      </View>
+    ) : null;
+  }
+
   renderVideo() {
     const {
       video,
@@ -559,6 +569,7 @@ export default class VideoPlayer extends Component {
             { marginTop: -this.getSizeStyles().height },
           ]}
         >
+          {this.renderOverlay()}
           <TouchableOpacity
             style={styles.overlayButton}
             onPress={() => {
@@ -590,6 +601,7 @@ export default class VideoPlayer extends Component {
     } else if (!isStarted) {
       return (
         <View style={[styles.preloadingPlaceholder, this.getSizeStyles(), style]}>
+          {this.renderOverlay()}
           {this.renderStartButton()}
         </View>
       );

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "react": "*",
     "react-native": "*",
     "react-native-vector-icons": ">= 2.1.0",
-    "react-native-video": "^2.0.0"
+    "react-native-video": "^5.0.0"
   },
   "devDependencies": {
     "eslint": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-video-player",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "A video player for React Native with controls",
   "main": "index.js",
   "scripts": {
@@ -21,7 +21,7 @@
     "react": "*",
     "react-native": "*",
     "react-native-vector-icons": ">= 2.1.0",
-    "react-native-video": "^5.0.0"
+    "react-native-video": ">=5"
   },
   "devDependencies": {
     "eslint": "^3.4.0",


### PR DESCRIPTION
This change adds a new `renderOverlayComponent` prop that allows to render something on top of the video, but under controls / play button.

**Example:**

```
        <VideoPlayer
          video={{uri}}
          style={styles.video}
          videoWidth={320}
          videoHeight={240}
          renderOverlayComponent={() => (
            <Text
              style={{
                color: 'white',
                position: 'absolute',
                right: 20,
                bottom: 20,
              }}>
              Testing
            </Text>
          )}
        />
```

![video-player](https://user-images.githubusercontent.com/4928274/102632132-4de8e180-4157-11eb-9816-ebb51fa2a7ef.gif)
