### PR TITLE
Migrate PropTypes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Image, ImageBackground, Platform, StyleSheet, Text, TextInput, TouchableOpacity, View, ViewPropTypes } from 'react-native';
+import { Image, ImageBackground, Platform, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { ViewPropTypes, ImagePropTypes } from 'deprecated-react-native-prop-types';
 import Icon from 'react-native-vector-icons/MaterialIcons';
 import Video from 'react-native-video'; // eslint-disable-line
 
@@ -594,8 +595,8 @@ export default class VideoPlayer extends Component {
 
 VideoPlayer.propTypes = {
   video: Video.propTypes.source,
-  thumbnail: Image.propTypes.source,
-  endThumbnail: Image.propTypes.source,
+  thumbnail: ImagePropTypes.source,
+  endThumbnail: ImagePropTypes.source,
   videoWidth: PropTypes.number,
   videoHeight: PropTypes.number,
   duration: PropTypes.number,
@@ -629,7 +630,7 @@ VideoPlayer.propTypes = {
     seekBarKnob: ViewPropTypesVar.style,
     seekBarKnobSeeking: ViewPropTypesVar.style,
     seekBarBackground: ViewPropTypesVar.style,
-    thumbnail: Image.propTypes.style,
+    thumbnail: ImagePropTypes.style,
     playButton: ViewPropTypesVar.style,
     playArrow: Icon.propTypes.style,
     durationText: ViewPropTypesVar.style

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "eslint-plugin-import": "^1.14.0",
     "eslint-plugin-jsx-a11y": "^2.2.1",
     "eslint-plugin-react": "^6.2.0"
+  },
+  "dependencies": {
+    "deprecated-react-native-prop-types": "^2.3.0"
   }
 }


### PR DESCRIPTION
on React-native version 6.0.0 
ViewPropTypes and Image.propTypes has been removed from React Native. 
This is PR is to Migrate to ViewPropTypes and Image.propTypes to 'deprecated-react-native-prop-types'.
