### PR TITLE
fix RCTVIEW [{flexGrow:<<Nan>>}] is not usable as a native method argument #126 issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ export default class VideoPlayer extends Component {
       duration: 0,
       isSeeking: false,
     };
-
+    
     this.seekBarWidth = 200;
     this.wasPlayingBeforeSeek = props.autoplay;
     this.seekTouchStart = 0;
@@ -446,7 +446,7 @@ export default class VideoPlayer extends Component {
       >
         <View
           style={[
-            { flexGrow: this.state.progress },
+            this.state.progress && {flexGrow: this.state.progress },
             styles.seekBarProgress,
             customStyles.seekBarProgress,
           ]}
@@ -470,7 +470,7 @@ export default class VideoPlayer extends Component {
         ) : null }
         <View style={[
           styles.seekBarBackground,
-          { flexGrow: 1 - this.state.progress },
+          this.state.progress && { flexGrow: 1 - this.state.progress },
           customStyles.seekBarBackground,
         ]} />
       </View>


### PR DESCRIPTION
Issue https://github.com/cornedor/react-native-video-player/issues/126 has been resolved.
![image](https://user-images.githubusercontent.com/36878262/189174832-2844b9d9-d84d-44ce-a039-8ec4268f0e11.png)