### PR TITLE
feat: allow to start the video programatically

### DIFF
--- a/index.js
+++ b/index.js
@@ -376,6 +376,21 @@ export default class VideoPlayer extends Component {
     this.seek(0);
     this.showControls();
   }
+  
+  start() {
+    if (this.props.onStart) {
+      this.props.onStart();
+    }
+
+    this.setState(state => ({
+      isPlaying: true,
+      isStarted: true,
+      hasEnded: false,
+      progress: state.progress === 1 ? 0 : state.progress,
+    }));
+
+    this.hideControls();
+  }
 
   pause() {
     this.player && this.player.setNativeProps({


### PR DESCRIPTION
This allows triggering the video start without the need to click on the button provided by the player.
It can be helpful to use this player in a grid-like Instagram where you start video playback without user action.