### PR TITLE
Fix resume when autoPlay is false

### DIFF
--- a/index.js
+++ b/index.js
@@ -398,6 +398,7 @@ export default class VideoPlayer extends Component {
   resume() {
     this.setState({
       isPlaying: true,
+      isStarted: true,
     });
     this.showControls();
   }


### PR DESCRIPTION
Fixed: `resume` method doesn't play the video when autoPlay is false.