### PR TITLE
fix: onPlaybackStateChanged now takes an optional callback (now the same as all other event handlers)

### DIFF
--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -41,6 +41,7 @@ type RenderVideoProps = Pick<
   | 'onLoad'
   | 'onMutePress'
   | 'onPlayPress'
+  | 'onPlaybackStateChanged'
   | 'onProgress'
   | 'onShowControls'
   | 'pauseOnPress'
@@ -71,6 +72,7 @@ export const RenderVideo = memo(
       onLoad,
       onMutePress,
       onPlayPress,
+      onPlaybackStateChanged,
       onProgress,
       onShowControls,
       pauseOnPress,
@@ -212,9 +214,10 @@ export const RenderVideo = memo(
 
     const _onPlaybackStateChanged = useCallback(
       (data: OnPlaybackStateChangedData) => {
+        if (onPlaybackStateChanged) onPlaybackStateChanged(data);
         if (data.isPlaying !== isPlaying) setIsPlaying(data.isPlaying);
       },
-      [isPlaying]
+      [isPlaying, onPlaybackStateChanged]
     );
 
     const onToggleFullScreen = useCallback(() => {


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the documentation with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->
## Summary
`onPlaybackStateChanged` currently does not take an optional callback.

This pull request adds that optional callback, so users can hook into the `onPlaybackStateChanged` event handler in the underlying `react-native-video` `Video` component.

### Motivation
This repo is phenomenally useful.
I would like to use this repo, along with `onPlaybackStateChanged` as an event handler hook for the underlying video.
However, there is currently a bug that means `onPlaybackStateChanged` cannot be passed a handler through this repo's props.

This is the only overridden callback into `react-native-video`'s `Video` component that does not take a user-provided optional callback:
```
<Video
  {...props}
  ref={videoRef}
  style={[styles.video, sizeStyle, style, customStyles.video]}
  muted={muted || isMuted}
  paused={paused || !isPlaying}
  onProgress={_onProgress}
  onEnd={_onEnd}
  onLoad={_onLoad}
  source={source}
  resizeMode={resizeMode}
  onPlaybackStateChanged={_onPlaybackStateChanged}
/>
```
`_onProgress`, `_onEnd`, `_onLoad` all start with an `if (callBack) callback()`.
This PR adds the same logic to `_onPlaybackStateChanged`.

### Changes
Effectively a one line change:
```
--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -41,6 +41,7 @@ type RenderVideoProps = Pick<
   | 'onLoad'
   | 'onMutePress'
   | 'onPlayPress'
+  | 'onPlaybackStateChanged'
   | 'onProgress'
   | 'onShowControls'
   | 'pauseOnPress'
@@ -71,6 +72,7 @@ export const RenderVideo = memo(
       onLoad,
       onMutePress,
       onPlayPress,
+      onPlaybackStateChanged,
       onProgress,
       onShowControls,
       pauseOnPress,
@@ -212,9 +214,10 @@ export const RenderVideo = memo(
 
     const _onPlaybackStateChanged = useCallback(
       (data: OnPlaybackStateChangedData) => {
+        if (onPlaybackStateChanged) onPlaybackStateChanged(data);
         if (data.isPlaying !== isPlaying) setIsPlaying(data.isPlaying);
       },
-      [isPlaying]
+      [isPlaying, onPlaybackStateChanged]
     );
 
     const onToggleFullScreen = useCallback(() => {
```

## Test plan
