### PR TITLE
fix: add “types” to root of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
       }
     }
   },
+  "types": "./lib/typescript/commonjs/src/index.d.ts",
   "files": [
     "src",
     "lib",


### PR DESCRIPTION
## Summary

Currently, package.json has this section:

```
  "exports": {
    ".": {
      "import": {
        "types": "./lib/typescript/module/src/index.d.ts",
        "default": "./lib/module/index.js"
      },
      "require": {
        "types": "./lib/typescript/commonjs/src/index.d.ts",
        "default": "./lib/commonjs/index.js"
      }
    }
  },
```

However, [Typescript requires the types to be defined at the root level in package.json](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package).

This should allow users to uninstall `@types/react-native-video-player`.

### Motivation

I recently had a PR merged which added the `customStyles.thumbnailImage` property, but when I used the new version of the library in my project, Typescript complained that the new property wasn't defined. I realized that I still had `@types/react-native-video-player` installed, which hadn't been updated yet, so I uninstalled it, but then Typescript couldn't find the Typescript definitions at all. I did some research and found out that the definitions file needs to be added at the root level of package.json.

### Changes

I added `"types": "./lib/typescript/commonjs/src/index.d.ts"` to the root of package.json.

## Test plan

After publishing to npm, install the new version in a project, uninstall `@types/react-native-video-player` and make sure Typescript can find the definitions.