### PR TITLE
feat: add possibility to render an overlay component on video

### DIFF
--- a/docs/docs/api/properties.md
+++ b/docs/docs/api/properties.md
@@ -106,6 +106,13 @@ The `react-native-video-player` component exposes a wide range of properties to 
 
 ---
 
+### `renderOverlayComponent`
+- **Type**: `function`
+- **Default**: `undefined`
+- **Description**: Renders an overlay component on top of the video, but under controls / play button.
+
+---
+
 ### `resizeMode`
 - **Type**: `string`
 - **Default**: `'contain'`

--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -1,0 +1,20 @@
+import { memo, type ReactNode } from 'react';
+import { StyleSheet, View } from 'react-native';
+
+interface OverlayProps {
+  renderOverlayComponent?: () => ReactNode;
+}
+
+export const Overlay = memo(({ renderOverlayComponent }: OverlayProps) => {
+  if (!renderOverlayComponent) return null;
+  return (
+    <View style={styles.overlayContainer}>{renderOverlayComponent()}</View>
+  );
+});
+
+const styles = StyleSheet.create({
+  overlayContainer: {
+    ...StyleSheet.absoluteFillObject,
+    pointerEvents: 'none',
+  },
+});

--- a/src/Thumbnail.tsx
+++ b/src/Thumbnail.tsx
@@ -6,7 +6,8 @@ import {
   TouchableOpacity,
 } from 'react-native';
 import type { CustomStyles, VideoPlayerProps } from './index';
-import { memo } from 'react';
+import { memo, type ReactNode } from 'react';
+import { Overlay } from './Overlay';
 
 interface StartButtonProps {
   onStart: () => void;
@@ -23,6 +24,7 @@ interface ThumbnailProps extends StartButtonProps {
   customStylesThumbnailImage: CustomStyles['thumbnailImage'];
   customStylesPlayButton: CustomStyles['playButton'];
   customStylesPlayArrow: CustomStyles['playArrow'];
+  renderOverlayComponent?: () => ReactNode;
 }
 
 export const StartButton = ({
@@ -53,6 +55,7 @@ export const Thumbnail = memo(
     customStylesThumbnailImage,
     customStylesPlayButton,
     customStylesPlayArrow,
+    renderOverlayComponent,
   }: ThumbnailProps) => {
     return (
       <ImageBackground
@@ -60,6 +63,7 @@ export const Thumbnail = memo(
         imageStyle={customStylesThumbnailImage}
         style={[styles.thumbnail, sizeStyles, style, customStylesThumbnail]}
       >
+        <Overlay renderOverlayComponent={renderOverlayComponent} />
         <StartButton
           customStylesPlayButton={customStylesPlayButton}
           onStart={onStart}

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -17,6 +17,7 @@ import Video, {
 import { Controls, type ProgressRef } from './controls/Controls';
 import { Platform, StyleSheet, TouchableOpacity, View } from 'react-native';
 import type { AnimationRef } from './controls/ControlsAnimatedWrapper';
+import { Overlay } from './Overlay';
 
 export interface VideoInternalRef extends VideoRef {
   onStart: () => void;
@@ -46,6 +47,7 @@ type RenderVideoProps = Pick<
   | 'onShowControls'
   | 'pauseOnPress'
   | 'paused'
+  | 'renderOverlayComponent'
   | 'repeat'
   | 'resizeMode'
   | 'showDuration'
@@ -77,6 +79,7 @@ export const RenderVideo = memo(
       onShowControls,
       pauseOnPress,
       paused,
+      renderOverlayComponent,
       repeat = false,
       resizeMode = 'contain',
       showDuration = false,
@@ -257,6 +260,7 @@ export const RenderVideo = memo(
             if (fullScreenOnLongPress) onToggleFullScreen();
           }}
         />
+        <Overlay renderOverlayComponent={renderOverlayComponent} />
         <Controls
           ref={controlsRef}
           customStyles={customStyles}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,7 @@ import {
   useMemo,
   useRef,
   useImperativeHandle,
+  type ReactNode,
 } from 'react';
 import {
   StyleSheet,
@@ -24,6 +25,7 @@ import {
   type ReactVideoProps,
   type ReactVideoSource,
 } from 'react-native-video';
+import { Overlay } from './Overlay';
 import { StartButton, Thumbnail } from './Thumbnail';
 import { RenderVideo, type VideoInternalRef } from './Video';
 
@@ -79,6 +81,7 @@ export interface VideoPlayerProps extends ReactVideoProps {
   onStart?: () => void;
   pauseOnPress?: boolean;
   paused?: boolean;
+  renderOverlayComponent?: () => ReactNode;
   resizeMode?: ResizeMode;
   showDuration?: boolean;
   source: ReactVideoSource;
@@ -97,6 +100,7 @@ const VideoPlayer = forwardRef<VideoPlayerRef, VideoPlayerProps>(
       endWithThumbnail,
       onStart,
       onEnd,
+      renderOverlayComponent,
       style,
       thumbnail,
       videoHeight = 1080,
@@ -165,17 +169,21 @@ const VideoPlayer = forwardRef<VideoPlayerRef, VideoPlayerProps>(
             customStylesThumbnailImage={customStyles.thumbnailImage}
             customStylesPlayButton={customStyles.playButton}
             customStylesPlayArrow={customStyles.playArrow}
+            renderOverlayComponent={renderOverlayComponent}
           />
         );
       if (!isStarted)
         return (
-          <View style={[styles.preloadingPlaceholder, sizeStyles, style]}>
-            <StartButton
-              onStart={_onStart}
-              customStylesPlayButton={customStyles.playButton}
-              customStylesPlayArrow={customStyles.playArrow}
-            />
-          </View>
+          <>
+            <Overlay renderOverlayComponent={renderOverlayComponent} />
+            <View style={[styles.preloadingPlaceholder, sizeStyles, style]}>
+              <StartButton
+                onStart={_onStart}
+                customStylesPlayButton={customStyles.playButton}
+                customStylesPlayArrow={customStyles.playArrow}
+              />
+            </View>
+          </>
         );
       return (
         <RenderVideo
@@ -185,6 +193,7 @@ const VideoPlayer = forwardRef<VideoPlayerRef, VideoPlayerProps>(
           customStyles={customStyles}
           autoplay={autoplay}
           onEnd={_onEnd}
+          renderOverlayComponent={renderOverlayComponent}
           sizeStyle={sizeStyles}
         />
       );
@@ -197,6 +206,7 @@ const VideoPlayer = forwardRef<VideoPlayerRef, VideoPlayerProps>(
       sizeStyles,
       _onStart,
       customStyles,
+      renderOverlayComponent,
       rest,
       autoplay,
       _onEnd,


### PR DESCRIPTION
<!--
Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

- Update the documentation
If you've added new functionality, update the documentation with an entry for your prop or event.
The entry should be inserted in alphabetical order.

- Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

- Focus the PR on only one area
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

- Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
-->

## Summary

This change adds a new `renderOverlayComponent` prop that allows to render something on top of the video, but under controls / play button.

**Example:**

```
        <VideoPlayer
          source={{uri}}
          videoWidth={320}
          videoHeight={240}
          renderOverlayComponent={() => (
            <Text
              style={{
                color: 'white',
                position: 'absolute',
                right: 20,
                bottom: 20,
              }}>
              Testing
            </Text>
          )}
        />
```

![video-player](https://user-images.githubusercontent.com/4928274/102632132-4de8e180-4157-11eb-9816-ebb51fa2a7ef.gif)
